### PR TITLE
Add file and line numbers to the generated spec methods

### DIFF
--- a/shard.yml
+++ b/shard.yml
@@ -1,6 +1,6 @@
 name: athena-spec
 
-version: 0.2.0
+version: 0.2.1
 
 crystal: 0.35.0
 

--- a/spec/athena-spec_spec.cr
+++ b/spec/athena-spec_spec.cr
@@ -25,7 +25,7 @@ struct ExampleSpec < ASPEC::TestCase
   end
 
   # A pending test.
-  def ptest_substract : Nil
+  def ptest_subtract : Nil
     @target.substract(10, 5).should eq 5
   end
 end

--- a/src/test_case.cr
+++ b/src/test_case.cr
@@ -293,13 +293,13 @@ abstract struct Athena::Spec::TestCase
 
               {% if provider_method_return_type == Hash || provider_method_return_type == NamedTuple %}
                 instance.{{data_provider_method_name.id}}.each do |name, args|
-                  {{method.id}} "#{{{description}}} #{name}", focus: {{focus}}, tags: {{tags}} do
+                  {{method.id}} "#{{{description}}} #{name}", file: {{test.filename}}, line: {{test.line_number}}, end_line: {{test.end_line_number}}, focus: {{focus}}, tags: {{tags}} do
                     instance.{{test.name.id}} *args
                   end
                 end
               {% elsif provider_method_return_type == Array || provider_method_return_type == Tuple %}
                 instance.{{data_provider_method_name.id}}.each_with_index do |args, idx|
-                  {{method.id}} "#{{{description}}} #{idx}", focus: {{focus}}, tags: {{tags}} do
+                  {{method.id}} "#{{{description}}} #{idx}", file: {{test.filename}}, line: {{test.line_number}}, end_line: {{test.end_line_number}}, focus: {{focus}}, tags: {{tags}} do
                     instance.{{test.name.id}} *args
                   end
                 end
@@ -308,7 +308,7 @@ abstract struct Athena::Spec::TestCase
               {% end %}
             {% end %}
           {% else %}
-            {{method.id}} {{description}}, focus: {{focus}}, tags: {{tags}} do
+            {{method.id}} {{description}}, file: {{test.filename}}, line: {{test.line_number}}, end_line: {{test.end_line_number}}, focus: {{focus}}, tags: {{tags}} do
               instance.{{test.name.id}}
             end
           {% end %}


### PR DESCRIPTION
Add filename and line numbers to generated spec methods:

Before:
```cr
F*..F...F.......

Pending:
  ExampleSpec subtract

Failures:

  1) ExampleSpec add
     Failure/Error: @target.add(1, 2).should eq 4

       Expected: 4
            got: 3

     # spec/athena-spec_spec.cr:24

  2) DataProviderTest squares two
     Failure/Error: (value ** 2).should eq expected

       Expected: 5
            got: 4

     # spec/athena-spec_spec.cr:55

  3) DataProviderTest cubes 0
     Failure/Error: (value ** 3).should eq expected

       Expected: 9
            got: 8

     # spec/athena-spec_spec.cr:75

Finished in 334.79 milliseconds
16 examples, 3 failures, 0 errors, 1 pending

Failed examples:

crystal spec src/test_case.cr:256 # ExampleSpec add
crystal spec src/test_case.cr:256 # DataProviderTest squares two
crystal spec src/test_case.cr:256 # DataProviderTest cubes 0
```

After:
```cr
F*..F...F.......

Pending:
  ExampleSpec subtract

Failures:

  1) ExampleSpec add
     Failure/Error: @target.add(1, 2).should eq 4

       Expected: 4
            got: 3

     # spec/athena-spec_spec.cr:24

  2) DataProviderTest squares two
     Failure/Error: (value ** 2).should eq expected

       Expected: 5
            got: 4

     # spec/athena-spec_spec.cr:55

  3) DataProviderTest cubes 0
     Failure/Error: (value ** 3).should eq expected

       Expected: 9
            got: 8

     # spec/athena-spec_spec.cr:75

Finished in 329.93 milliseconds
16 examples, 3 failures, 0 errors, 1 pending

Failed examples:

crystal spec spec/athena-spec_spec.cr:23 # ExampleSpec add
crystal spec spec/athena-spec_spec.cr:54 # DataProviderTest squares two
crystal spec spec/athena-spec_spec.cr:74 # DataProviderTest cubes 0
```

The failure locations now correctly report the related test method.